### PR TITLE
Update ethash to 0.6.0 which adds optimisations for x86 cpu's

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,7 +68,7 @@ hunter_add_package(jsoncpp)
 find_package(jsoncpp CONFIG REQUIRED)
 
 hunter_add_package(ethash)
-find_package(ethash CONFIG REQUIRED)
+find_package(ethash 0.6.0 CONFIG REQUIRED)
 
 configureProject()
 

--- a/cmake/Hunter/config.cmake
+++ b/cmake/Hunter/config.cmake
@@ -8,3 +8,10 @@ hunter_config(
     Boost
     VERSION 1.75.0
 )
+
+hunter_config(
+    ethash
+    VERSION 0.6.0
+    SHA1 4bfa26b389d1f89a60053de04b2a29feab20f67b
+    URL https://github.com/chfast/ethash/archive/refs/tags/v0.6.0.tar.gz
+)


### PR DESCRIPTION
Updates ethash to version 0.6.0 which improves performance on x86 cpu's with bmi instruction support.